### PR TITLE
Add configuration, configurable routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ After installing the gem, you get the middleware which will intercept requests t
   * batch_sequential ```(/api/v1/batch_sequential)```
   * batch_parallel ```(/api/v1/batch_parallel)```
 
+To use custom URLs, add a configuration block to your app initialization. Example:
+
+```ruby
+BatchRequestApi.configure do |config|
+  config.batch_sequential_path = '/api/v1/batch_sequential'
+  config.batch_parallel_path = '/api/v1/batch_parallel'
+end
+```
+
+API endpoint can be disabled by setting the path to a falsy value (`nil`/`false`).
+
 ### Sequential Usage
 
 This is the simplest way to implement batch. One network request to ```/api/v1/batch_sequential``` containing the batched payload will work with a regular rails controller.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,9 @@
 Rails.application.routes.draw do
-  scope :api do
-    namespace :v1, defaults: {format: 'json'} do
-      resources :batch_sequential
-      resources :batch_parallel
-    end
+  if batch_sequential_path = BatchRequestApi.config.batch_sequential_path
+    post batch_sequential_path, constraints: { format: :json }
+  end
+
+  if batch_parallel_path = BatchRequestApi.config.batch_parallel_path
+    post batch_parallel_path, constraints: { format: :json }
   end
 end

--- a/lib/batch_request_api.rb
+++ b/lib/batch_request_api.rb
@@ -2,6 +2,7 @@ require 'batch_request_api/version'
 require 'batch_request_api/railtie' if defined?(Rails)
 require 'batch_request_api/middleware'
 require 'batch_request_api/engine'
+require 'batch_request_api/configuration'
 
 module BatchRequestApi
   # Keep moving forward.

--- a/lib/batch_request_api/configuration.rb
+++ b/lib/batch_request_api/configuration.rb
@@ -1,0 +1,21 @@
+module BatchRequestApi
+  class << self
+    def config
+      @config ||= Configuration.new
+    end
+
+    def configure
+      yield(config)
+    end
+  end
+
+  class Configuration
+    attr_accessor :batch_sequential_path
+    attr_accessor :batch_parallel_path
+
+    def initialize
+      self.batch_sequential_path = '/api/v1/batch_sequential'
+      self.batch_parallel_path = '/api/v1/batch_parallel'
+    end
+  end
+end

--- a/lib/batch_request_api/middleware.rb
+++ b/lib/batch_request_api/middleware.rb
@@ -1,24 +1,34 @@
 require 'batch_request_api/batch_parallel'
 require 'batch_request_api/batch_sequential'
+require 'json'
 
 module BatchRequestApi
   class Middleware
     include BatchParallel
     include BatchSequential
-    require 'json'
+
+    PATH_INFO_HEADER_KEY  = 'PATH_INFO'.freeze
 
     def initialize(app)
       @app = app
     end
 
     def call(env)
-      if env['PATH_INFO'] == '/api/v1/batch_sequential'
+      if batch_sequential_path?(env[PATH_INFO_HEADER_KEY])
         batch_sequential(env)
-      elsif env['PATH_INFO'] == '/api/v1/batch_parallel'
+      elsif batch_parallel_path?(env[PATH_INFO_HEADER_KEY])
         batch_parallel(env)
       else
         @app.call(env) # regular RAILS CRUD
       end
+    end
+
+    def batch_sequential_path?(path)
+      path == BatchRequestApi.config.batch_sequential_path
+    end
+
+    def batch_parallel_path?(path)
+      path == BatchRequestApi.config.batch_parallel_path
     end
   end
 end

--- a/lib/batch_request_api/version.rb
+++ b/lib/batch_request_api/version.rb
@@ -1,3 +1,3 @@
 module BatchRequestApi
-  VERSION = "1.0.13"
+  VERSION = "1.0.14"
 end


### PR DESCRIPTION
This adds possibility to use customer URLs for `batch_sequential` and `batch_parallel` endpoints.

For achiving that, `Configuration` class has been introduced. 

Also, method `BatchRequestApi.configure` is available for setting the configuration values. When not specifying custom configuration, the default values are used. Because of that, this pull request is backward compatible.