### PR TITLE
Allow multiple configurable routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ To use custom URLs, add a configuration block to your app initialization. Exampl
 
 ```ruby
 BatchRequestApi.configure do |config|
-  config.batch_sequential_path = '/api/v1/batch_sequential'
-  config.batch_parallel_path = '/api/v1/batch_parallel'
+  config.batch_sequential_paths = ['/api/v1/batch_sequential']
+  config.batch_parallel_paths = ['/api/v1/batch_parallel']
 end
 ```
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,9 @@
 Rails.application.routes.draw do
-  if batch_sequential_path = BatchRequestApi.config.batch_sequential_path
+  BatchRequestApi.config.batch_sequential_paths.each do |batch_sequential_path|
     post batch_sequential_path, constraints: { format: :json }
   end
 
-  if batch_parallel_path = BatchRequestApi.config.batch_parallel_path
+  BatchRequestApi.config.batch_parallel_paths.each do |batch_parallel_path|
     post batch_parallel_path, constraints: { format: :json }
   end
 end

--- a/lib/batch_request_api/configuration.rb
+++ b/lib/batch_request_api/configuration.rb
@@ -10,12 +10,12 @@ module BatchRequestApi
   end
 
   class Configuration
-    attr_accessor :batch_sequential_path
-    attr_accessor :batch_parallel_path
+    attr_accessor :batch_sequential_paths
+    attr_accessor :batch_parallel_paths
 
     def initialize
-      self.batch_sequential_path = '/api/v1/batch_sequential'
-      self.batch_parallel_path = '/api/v1/batch_parallel'
+      self.batch_sequential_paths = ['/api/v1/batch_sequential']
+      self.batch_parallel_paths = ['/api/v1/batch_parallel']
     end
   end
 end

--- a/lib/batch_request_api/middleware.rb
+++ b/lib/batch_request_api/middleware.rb
@@ -14,21 +14,21 @@ module BatchRequestApi
     end
 
     def call(env)
-      if batch_sequential_path?(env[PATH_INFO_HEADER_KEY])
+      if is_batch_sequential_path?(env[PATH_INFO_HEADER_KEY])
         batch_sequential(env)
-      elsif batch_parallel_path?(env[PATH_INFO_HEADER_KEY])
+      elsif is_batch_parallel_path?(env[PATH_INFO_HEADER_KEY])
         batch_parallel(env)
       else
         @app.call(env) # regular RAILS CRUD
       end
     end
 
-    def batch_sequential_path?(path)
-      path == BatchRequestApi.config.batch_sequential_path
+    def is_batch_sequential_path?(path)
+      BatchRequestApi.config.batch_sequential_paths.include?(path)
     end
 
-    def batch_parallel_path?(path)
-      path == BatchRequestApi.config.batch_parallel_path
+    def is_batch_parallel_path?(path)
+      BatchRequestApi.config.batch_parallel_paths.include?(path)
     end
   end
 end

--- a/lib/batch_request_api/version.rb
+++ b/lib/batch_request_api/version.rb
@@ -1,3 +1,3 @@
 module BatchRequestApi
-  VERSION = "1.0.14"
+  VERSION = "1.0.15"
 end


### PR DESCRIPTION
Allow multiple batch_sequential_paths and batch_parallel_paths.

Useful for setting paths on different namespaces (eg. `/api/v1/` and `/api/v2/`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netflix/batch_request_api/5)
<!-- Reviewable:end -->
