### PR TITLE
Fix  'Missing :controller key on routes definition' in rails 5

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,11 @@
 Rails.application.routes.draw do
+  not_found_response = ->(env) { [404, {}, []] }
+
   BatchRequestApi.config.batch_sequential_paths.each do |batch_sequential_path|
-    post batch_sequential_path, constraints: { format: :json }
+    post batch_sequential_path, constraints: { format: :json }, to: not_found_response
   end
 
   BatchRequestApi.config.batch_parallel_paths.each do |batch_parallel_path|
-    post batch_parallel_path, constraints: { format: :json }
+    post batch_parallel_path, constraints: { format: :json }, to: not_found_response
   end
 end


### PR DESCRIPTION
I have the following error after running `rake middleware`. I use rails 5.2.1 and ruby 2.5.0

```
rake aborted!                                                                                                                                                                                                                                                                     
ArgumentError: Missing :controller key on routes definition, please check your routes.                                                                                                                                                                                            
/bundler_data/gems/newrelic_rpm-3.18.1.330/lib/new_relic/agent/instrumentation/rake.rb:28:in `invoke'                                                                                                                                                                             
/bundler_data/gems/rake-12.3.0/exe/rake:27:in `<top (required)>'                                                                                                                                                                                                                  
Tasks: TOP => middleware => environment                                                                                                                                                                                                                                           
(See full trace by running task with --trace)
```
Fixed it by adding `to:` to routes with `404` response.